### PR TITLE
Revert "ci: bump base image version to ubuntu:22.10"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY . .
 
 RUN make gar
 
-FROM ubuntu:22.10
+FROM ubuntu:20.04
 
 # Build ARGS
 ARG RUNNER_VERSION


### PR DESCRIPTION
This reverts commit 709f3b50b63e8533b61e93f7af4a3dfeb14465a0. GitHub is not ready yet to use Ubuntu 22: https://github.blog/changelog/2022-05-10-github-actions-beta-of-ubuntu-22-04-for-github-hosted-runners-is-now-available/